### PR TITLE
implementing Answers API Documentation

### DIFF
--- a/src/docs/Docs.js
+++ b/src/docs/Docs.js
@@ -29,6 +29,10 @@ const options = {
         {
             name: "Question",
             description: "Operations related to question entities",
+        },
+        {
+            step: "Answers",
+            description: "Operations related to answer entities",
         }
     ],
     paths: {
@@ -564,7 +568,158 @@ const options = {
                 },
             },
         },
-        
+        // Answer Documentation
+        "/api/v1/answers/{id}": {
+            get: {
+                tags: ["Answers"],
+                summary: "Get All Answers",
+                description: "Get all Answers",
+                parameters: [
+                    {
+                        name: "id",
+                        in: "path",
+                        required: true,
+                        schema: {
+                            type: "string",
+                        },
+                    },
+                ],
+                responses: {
+                    200: {
+                        description: "All Answers are retrieved successfully",
+                    },
+                    500: {
+                        
+                        description: "Internal Server Error",
+                    },
+                },
+            },
+            post: {
+                tags: ["Answers"],
+                summary: "Create Answer",
+                description: "Create a new Answer",
+                parameters: [
+                    {
+                        name: "id",
+                        in: "path",
+                        required: true,
+                        schema: {
+                            type: "string",
+                        },
+                    },
+                ],
+                requestBody: {
+                    content: {
+                        "multipart/form-data": {
+                            schema: {
+                                type: "object",
+                                properties: {
+                                    step: {
+                                        type: "string",
+                                    },
+                                    stepDescription: {
+                                        type: "string",
+                                    },
+                                    stepImage: {
+                                        type: "string",
+                                        format: "binary",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    required: true,
+                },
+                responses: {
+                    201: {
+                        description: "New Answer created successfully",
+                    },
+                    400: {
+                        description: "Bad Request",
+                    },
+                    500: {
+                        description: "Internal Server Error",
+                    },
+                },
+            },
+            put: {
+                tags: ["Answers"],
+                summary: "Update Answer",
+                description: "Update Answer",
+                parameters: [
+                    {
+                        name: "id",
+                        in: "path",
+                        required: true,
+                        schema: {
+                            type: "string",
+                        },
+                    },
+                ],
+                requestBody: {
+                    content: {
+                        "multipart/form-data": {
+                            schema: {
+                                type: "object",
+                                properties: {
+                                    step: {
+                                        type: "string",
+                                    },
+                                    stepDescription: {
+                                        type: "string",
+                                    },
+                                    stepImage: {
+                                        type: "string",
+                                        format: "binary",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    required: true,
+                },
+                responses: {
+                    201: {
+                        description: "Answer Updated successfully",
+                    },
+                    400: {
+                        description: "Bad Request",
+                    },
+                    500: {
+                        description: "Internal Server Error",
+                    },
+                },
+            },
+            delete: {
+                tags: ["Answers"],
+                summary: "Delete Answer",
+                description: "Answer ID to be deleted",
+                parameters: [
+                    {
+                        name: "id",
+                        in: "path",
+                        required: true,
+                        schema: {
+                            type: "string",
+                        },
+                    },
+                ],
+                responses: {
+                    200: {
+                        description: "Answer deleted",
+                    },
+                    400: {
+                        description: "Bad Request",
+                    },
+                    404: {
+                        description: "Answer not found",
+                    },
+                    500: {
+                        description: "Internal Server Error",
+                    },
+                },
+            },
+        },
     },
     
     components: {


### PR DESCRIPTION
### What this PR do?
this PR implements answers api endpoints documentation

### How will this manually be tested
head over to localhost:4000/api/v1/answers/{id} with POST http method to create answer for a question with {id}
head over to localhost:4000/api/v1/answers/{id} with GET http method to retrieve all answers for a question with {id}
head over to localhost:4000/api/v1/answers/{id} with PUT http method to update answer with {id}
head over to localhost:4000/api/v1/answers/{id} with DELETE http method to delete answer with {id}
